### PR TITLE
Add respective ports to socket crossdomain policy

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -28,6 +28,7 @@ class SnowflakeWorld(MetaplaceWorldServer):
             world_owner='crowdcontrol',
             stylesheet_id='87.5309',
             policy_domain=config.POLICY_DOMAIN,
+            policy_port=config.PORT,
             server_type=ServerType.LIVE,
             build_type=BuildType.RELEASE
         )

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     global world_server, policy_server
 
     try:
-        policy_server = SocketPolicyServer(config.POLICY_DOMAIN)
+        policy_server = SocketPolicyServer(config.POLICY_DOMAIN, 843)
         world_server = SnowflakeWorld()
         world_server.listen(config.PORT)
 


### PR DESCRIPTION
This will generate the correct socket crossdomain policy.

You can safe set these ports once clients will connect just in these ports :)