### PR TITLE
Fixed "Wave Boost" stamp condition

### DIFF
--- a/app/engine/cards.py
+++ b/app/engine/cards.py
@@ -305,10 +305,10 @@ class CardObject(Card):
         if len(ninja_targets) >= 3 and self.element == 's':
             # Unlock "Huge Heal" stamp
             self.client.unlock_stamp(478)
-
-            if is_combo and self.element == 'w':
-                # Unlock "Wave Boost" stamp
-                self.client.unlock_stamp(481)
+        
+        if ninja_targets and is_combo and self.element == 'w':
+            # Unlock "Wave Boost" stamp
+            self.client.unlock_stamp(481)
 
         if ninja_targets and is_combo and self.element == 's':
             # Unlock "Snow Shield" stamp


### PR DESCRIPTION
As described [here](https://github.com/Lekuruu/snowflake/blob/8b980da4db83a200cde548d2ef12d9bfe10236ab/app/engine/cards.py#L243) the wave effect applies in all ninjas, so this stamp doesn't need to check if all ninjas is in card target area.