### PR TITLE
Refactor policy server configuration

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -20,9 +20,6 @@ VERSION="FY15-20150206 (4954)r"
 # e.g. http://media.localhost or http://localhost/media
 MEDIA_LOCATION="http://media.localhost"
 
-# Leave this unchanged, unless you know what you're doing
-POLICY_DOMAIN="*"
-
 # If you have issues with the game being in a wierd position, try setting this to True
 APPLY_WINDOWMANAGER_OFFSET=False
 
@@ -32,7 +29,12 @@ ENABLE_BETA=False
 ## Debug settings
 ENABLE_DEBUG_PLAYERS=False
 ENABLE_DEBUG_LOGGING=False
-DISABLE_POLICY_SERVER=False
 DISABLE_ENEMY_AI=False
 DISABLE_REWARDS=False
 DISABLE_STAMPS=False
+
+## Policy Server configuration (optional)
+# Leave this untouched, unless you know what you are doing
+ENABLE_POLICY_SERVER=False
+POLICY_DOMAIN="*"
+POLICY_PORT="*"

--- a/config.py
+++ b/config.py
@@ -24,7 +24,7 @@ try:
     MEDIA_DOMAIN = urlparse(MEDIA_LOCATION).hostname
 
     POLICY_DOMAIN = os.environ.get('POLICY_DOMAIN', '*')
-    POLICY_PORT = int(os.environ.get('POLICY_PORT', '*'))
+    POLICY_PORT = os.environ.get('POLICY_PORT', '*')
     ENABLE_POLICY_SERVER = os.environ.get('ENABLE_POLICY_SERVER', 'False').lower() == 'true'
 
     APPLY_WINDOWMANAGER_OFFSET = os.environ.get('APPLY_WINDOWMANAGER_OFFSET', 'False').lower() == 'true'

--- a/config.py
+++ b/config.py
@@ -14,8 +14,8 @@ try:
 
     POSTGRES_HOST = os.environ.get('POSTGRES_HOST', 'localhost')
     POSTGRES_PORT = int(os.environ.get('POSTGRES_PORT', '5432'))
-    POSTGRES_USER = os.environ.get('POSTGRES_USER')
-    POSTGRES_DBNAME = os.environ.get('POSTGRES_DBNAME')
+    POSTGRES_DBNAME = os.environ.get('POSTGRES_DBNAME', 'postgres')
+    POSTGRES_USER = os.environ.get('POSTGRES_USER', 'postgres')
     POSTGRES_PASSWORD = os.environ.get('POSTGRES_PASSWORD')
 
     PORT = int(os.environ.get('PORT', '7002'))

--- a/config.py
+++ b/config.py
@@ -22,12 +22,14 @@ try:
 
     MEDIA_LOCATION = os.environ.get('MEDIA_LOCATION')
     MEDIA_DOMAIN = urlparse(MEDIA_LOCATION).hostname
+
     POLICY_DOMAIN = os.environ.get('POLICY_DOMAIN', '*')
+    POLICY_PORT = int(os.environ.get('POLICY_PORT', '*'))
+    ENABLE_POLICY_SERVER = os.environ.get('ENABLE_POLICY_SERVER', 'False').lower() == 'true'
 
     APPLY_WINDOWMANAGER_OFFSET = os.environ.get('APPLY_WINDOWMANAGER_OFFSET', 'False').lower() == 'true'
     ENABLE_DEBUG_PLAYERS = os.environ.get('ENABLE_DEBUG_PLAYERS', 'False').lower() == 'true'
     ENABLE_DEBUG_LOGGING = os.environ.get('ENABLE_DEBUG_LOGGING', 'False').lower() == 'true'
-    DISABLE_POLICY_SERVER = os.environ.get('DISABLE_POLICY_SERVER', 'False').lower() == 'true'
     DISABLE_ENEMY_AI = os.environ.get('DISABLE_ENEMY_AI', 'False').lower() == 'true'
     DISABLE_REWARDS = os.environ.get('DISABLE_REWARDS', 'False').lower() == 'true'
     DISABLE_STAMPS = os.environ.get('DISABLE_STAMPS', 'False').lower() == 'true'

--- a/main.py
+++ b/main.py
@@ -30,11 +30,14 @@ if __name__ == "__main__":
     global world_server, policy_server
 
     try:
-        policy_server = SocketPolicyServer(config.POLICY_DOMAIN, 843)
         world_server = SnowflakeWorld()
         world_server.listen(config.PORT)
 
-        if not config.DISABLE_POLICY_SERVER:
+        if config.ENABLE_POLICY_SERVER:
+            policy_server = SocketPolicyServer(
+                config.POLICY_DOMAIN,
+                config.POLICY_PORT
+            )
             policy_server.listen(843)
 
         reactor.run()


### PR DESCRIPTION
This will make the policy server optional and disabled by default, since it‘s not really required. It can still be enabled inside the .env file. I have not tested this yet, so I will merge it later.