### PR TITLE
Fix "Heal 15" stamp

### DIFF
--- a/app/engine/game.py
+++ b/app/engine/game.py
@@ -638,9 +638,6 @@ class Game:
                 if isinstance(target, Ninja):
                     ninja.heal_target(target)
 
-                    if ninja.name == 'Snow':
-                        ninja.heals += 1
-
                 if ninja.heals >= 15:
                     # Unlock "Heal 15" stamp
                     self.unlock_stamp(477)

--- a/app/objects/ninjas.py
+++ b/app/objects/ninjas.py
@@ -359,6 +359,7 @@ class Ninja(GameObject):
         if self.name != 'Snow':
             return
 
+        self.heals += 1
         self.heal_animation()
         self.client.update_cards()
         time.sleep(0.4)


### PR DESCRIPTION
I didn't account for the ninja's hp, when incrementing the `heals` count. This pr should fix that.