### PR TITLE
Fix "Heal 15 Stamp" being added for all ninjas

### DIFF
--- a/app/engine/game.py
+++ b/app/engine/game.py
@@ -640,7 +640,7 @@ class Game:
 
                 if ninja.heals >= 15:
                     # Unlock "Heal 15" stamp
-                    self.unlock_stamp(477)
+                    self.snow.unlock_stamp(477)
 
                 time.sleep(1)
 


### PR DESCRIPTION
When the snow ninja heal 15 times all ninjas earns the stamp.