### PR TITLE
Reset ninja's sprite settings after turn ends

### DIFF
--- a/app/engine/game.py
+++ b/app/engine/game.py
@@ -272,6 +272,9 @@ class Game:
                 client.selected_card = None
                 client.is_ready = False
 
+                # Reset ninja's rotation, if necessary
+                client.ninja.reset_sprite_settings()
+
                 if client.power_card_slots:
                     self.send_tip(TipPhase.CARD, client)
 


### PR DESCRIPTION
This basically ensures, that the ninjas won‘t end up like this for the whole game:

![image](https://github.com/Lekuruu/snowflake/assets/84310095/428045ca-cfe7-4802-9afe-5775ebf29c6c)
