### PR TITLE
Matchmaking improvements

### DIFF
--- a/app/engine/matchmaking.py
+++ b/app/engine/matchmaking.py
@@ -46,9 +46,24 @@ class MatchmakingQueue:
         players = [player]
 
         for element in elements:
-            if (matches := self.players.with_element(element, player.battle_mode)):
-                # TODO: Sort players by different criteria
-                players.append(matches[0])
+            matches = self.players.with_element(
+                element,
+                player.battle_mode
+            )
+
+            if not matches:
+                continue
+
+            # Sort by closest rank
+            players.sort(
+                key=lambda other: abs(
+                    player.object.snow_ninja_rank -
+                    other.object.snow_ninja_rank
+                )
+            )
+
+            # Add closest match
+            players.append(matches[0])
 
         if len(players) != 3:
             if not config.ENABLE_DEBUG_PLAYERS:


### PR DESCRIPTION
There are a few things I want to change in the matchmaking system:

- Match players with the closest rank together
- Add a matchmaking timeout error
- Allow for singleplayer tusk battles

There generally seem to be multiple error messages that were used:

```json
{
    "cjsnow_error.load.carddata": "Sorry! There was a problem loading\nyour battle. Please quit and try\nagain.",
    "cjsnow_error.award.coins": "Sorry! There was a problem saving\nyour coins. Please play again.",
    "cjsnow_error.load.usercards": "Sorry! There was a problem loading\nyour battle. Please quit and try\nagain.",
    "cjsnow_error.load.ninjaprogress": "Sorry! There was a problem loading\nyour battle. Please quit and try\nagain.",
    "cjsnow_error.award.ninjaprogress": "Sorry! There was a problem saving\nyour ninja progress. Please play\nagain.",
    "cjsnow_error.award.items": "Sorry! There was a problem saving\nyour reward. Please play again.",
    "cjsnow_error.load.userstamps": "Sorry! There was a problem loading\nyour battle. Please quit and try\nagain.",
    "cjsnow_error.award.stamps": "Sorry! There was a problem saving\nyour Stamp. Please play again.",
    "cjsnow_error.matchmaking.unavailable": "Sorry! There was a problem matching\nyou with other ninjas. Please try\nagain later.",
    "cjsnow_error.matchmaking.badjson": "Sorry! There was a problem matching\nyou with other ninjas. Please quit\nand try again.",
    "cjsnow_error.matchmaking.timeout": "We're still searching for ninjas\nto join you in battle...",
    "cjsnow_error.matchmaking.alreadyin": "Sorry! There was a problem matching\nyou with other ninjas. Please quit\nand try again.",
    "cjsnow_error.matchmaking.tryagain": "Sorry! There was a problem matching\nyou with other ninjas. Please try\nagain.",
    "cjsnow_error.load.userdata": "Sorry! There was a problem loading\nyour battle. Please quit and try\nagain.",
    "cjsnow_error.matchmaking.exit": "Sorry! There was a problem leaving\nyour battle.",
    "cjsnow_error.load.stampdata": "Sorry! There was a problem loading\nyour battle. Please quit and try\nagain.",
    "cjsnow_error.waiting.timeout": "Sorry! There was a problem loading\nyour battle. Please quit and try\nagain.",
}
```

Not sure how, and if I am gonna implement them.