### PR TITLE
Hide disconnected ninjas after round ends

### DIFF
--- a/app/engine/game.py
+++ b/app/engine/game.py
@@ -216,6 +216,10 @@ class Game:
 
             self.run_until_next_round()
 
+            for client in self.disconnected_clients:
+                # Hide disconnected ninjas
+                client.ninja.remove_object()
+
             if all(client.disconnected for client in self.clients):
                 # All players have disconnected
                 self.close()


### PR DESCRIPTION
Basically this:

![image](https://github.com/Lekuruu/snowflake/assets/84310095/5a957829-c6ee-43cb-92d5-3f18241cbde2)
