### PR TITLE
Allow for force-starting a match after a configured timeout

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -27,11 +27,11 @@ APPLY_WINDOWMANAGER_OFFSET=False
 # If you want to enable the beta features, set this to True
 ENABLE_BETA=False
 
-# Allows players to force-start a match
-ALLOW_SINGLEPLAYER_SNOW=False
-ALLOW_SINGLEPLAYER_TUSK=True
+# Will force-start the match after a certain amount of time
+ALLOW_FORCESTART_SNOW=False
+ALLOW_FORCESTART_TUSK=True
 
-# Matchmaking timeout for force-start
+# Timeout for the force-start to happen
 MATCHMAKING_TIMEOUT=30
 
 ## Policy Server configuration (optional)

--- a/.env_example
+++ b/.env_example
@@ -27,6 +27,13 @@ APPLY_WINDOWMANAGER_OFFSET=False
 # If you want to enable the beta features, set this to True
 ENABLE_BETA=False
 
+# Allows players to force-start a match
+ALLOW_SINGLEPLAYER_SNOW=False
+ALLOW_SINGLEPLAYER_TUSK=True
+
+# Matchmaking timeout for force-start
+MATCHMAKING_TIMEOUT=30
+
 ## Policy Server configuration (optional)
 # Leave this untouched, unless you know what you are doing
 ENABLE_POLICY_SERVER=False
@@ -34,7 +41,6 @@ POLICY_DOMAIN="*"
 POLICY_PORT="*"
 
 ## Debug settings
-ENABLE_DEBUG_PLAYERS=False
 ENABLE_DEBUG_LOGGING=False
 DISABLE_AUTHENTICATION=False
 DISABLE_ENEMY_AI=False

--- a/app/engine/matchmaking.py
+++ b/app/engine/matchmaking.py
@@ -119,29 +119,7 @@ class MatchmakingQueue:
         # Start game loop
         game.server.runThread(game.start)
 
-    def get_debug_players(self, players: List[Penguin]) -> List[Penguin]:
-        elements = ['snow', 'water', 'fire']
-        battle_mode = players[0].battle_mode
-
-        for player in players:
-            elements.remove(player.element)
-
-        for element in elements:
-            debug_player = Penguin(player.server, player.address)
-            debug_player.pid = -1
-            debug_player.name = f'Debug {element.title()} Player'
-            debug_player.element = element
-            debug_player.battle_mode = battle_mode
-            debug_player.in_queue = True
-            debug_player.is_ready = True
-            debug_player.logged_in = True
-            debug_player.disconnected = True
-            debug_player.object = player.object
-            players.append(debug_player)
-
-        return players
-
-    def get_none_players(self, players: List[Penguin]) -> List[Penguin]:
+    def insert_none_players(self, players: List[Penguin]) -> List[Penguin]:
         player_dict = {
             'fire': None,
             'snow': None,
@@ -167,7 +145,7 @@ class MatchmakingQueue:
             return
 
         # Fill up missing players with "None"
-        players = self.get_none_players([player])
+        players = self.insert_none_players([player])
 
         self.logger.info(f'Found match: {players}')
 

--- a/app/engine/matchmaking.py
+++ b/app/engine/matchmaking.py
@@ -132,11 +132,11 @@ class MatchmakingQueue:
         return list(player_dict.values())
 
     def fill_queue(self, player: Penguin) -> None:
-        if player.battle_mode == 0 and not config.ALLOW_SINGLEPLAYER_SNOW:
+        if player.battle_mode == 0 and not config.ALLOW_FORCESTART_SNOW:
             # Singleplayer snow is disabled
             return
 
-        if player.battle_mode == 1 and not config.ALLOW_SINGLEPLAYER_TUSK:
+        if player.battle_mode == 1 and not config.ALLOW_FORCESTART_TUSK:
             # Singleplayer tusk is disabled
             return
 

--- a/app/engine/matchmaking.py
+++ b/app/engine/matchmaking.py
@@ -25,7 +25,7 @@ class MatchmakingQueue:
         player.queue_time = time.time()
         player.in_queue = True
 
-        if (match := self.find_match(player)):
+        if len(match := self.find_match(player)) >= 3:
             self.logger.info(f'Found match: {match}')
 
             match_types = {
@@ -72,9 +72,6 @@ class MatchmakingQueue:
 
             # Add closest match
             players.append(matches[0])
-
-        if len(players) != 3:
-            return
 
         players.sort(key=lambda x: x.element)
         return players
@@ -146,8 +143,19 @@ class MatchmakingQueue:
             # Player has found a match
             return
 
+        # Find other players in queue
+        players = self.find_match(player)
+
+        for p in players:
+            required_time = config.MATCHMAKING_TIMEOUT / 2
+            time_in_queue = time.time() - p.queue_time
+
+            if time_in_queue < required_time:
+                # Player has not been in queue long enough
+                players.remove(p)
+
         # Fill up missing players with "None"
-        players = self.insert_none_players([player])
+        players = self.insert_none_players(players)
 
         self.logger.info(f'Found match: {players}')
 

--- a/app/engine/matchmaking.py
+++ b/app/engine/matchmaking.py
@@ -11,6 +11,7 @@ from .game import Game
 
 import logging
 import config
+import time
 
 class MatchmakingQueue:
     def __init__(self) -> None:
@@ -21,6 +22,7 @@ class MatchmakingQueue:
         self.players.add(player)
 
         player.logger.info(f'Joined matchmaking queue with "{player.element}"')
+        player.queue_time = time.time()
         player.in_queue = True
 
         if (match := self.find_match(player)):

--- a/app/engine/matchmaking.py
+++ b/app/engine/matchmaking.py
@@ -1,5 +1,7 @@
 
 from __future__ import annotations
+
+from twisted.internet import reactor
 from typing import List
 
 from ..objects.collections import Players
@@ -29,9 +31,12 @@ class MatchmakingQueue:
                 1: self.create_tusk_game
             }
 
-            match_types[player.battle_mode](*match)
+            return match_types[player.battle_mode](*match)
 
-        # TODO: Add matchmaking timeout error
+        reactor.callLater(
+            config.MATCHMAKING_TIMEOUT,
+            self.fill_queue, player
+        )
 
     def remove(self, player: Penguin) -> None:
         if player in self.players:
@@ -67,10 +72,7 @@ class MatchmakingQueue:
             players.append(matches[0])
 
         if len(players) != 3:
-            if not config.ENABLE_DEBUG_PLAYERS:
-                return
-
-            players = self.get_debug_players(players)
+            return
 
         players.sort(key=lambda x: x.element)
         return players
@@ -84,9 +86,9 @@ class MatchmakingQueue:
             player_select.send_payload(
                 'matchFound',
                 {
-                    1: fire.name,
-                    2: water.name,
-                    4: snow.name
+                    1: fire.name if fire else None,
+                    2: water.name if water else None,
+                    4: snow.name if snow else None
                 }
             )
 
@@ -105,9 +107,9 @@ class MatchmakingQueue:
             player_select.send_payload(
                 'matchFound',
                 {
-                    1: fire.name,
-                    2: water.name,
-                    4: snow.name
+                    1: fire.name if fire else None,
+                    2: water.name if water else None,
+                    4: snow.name if snow else None
                 }
             )
 
@@ -138,3 +140,40 @@ class MatchmakingQueue:
             players.append(debug_player)
 
         return players
+
+    def get_none_players(self, players: List[Penguin]) -> List[Penguin]:
+        player_dict = {
+            'fire': None,
+            'snow': None,
+            'water': None
+        }
+
+        for player in players:
+            player_dict[player.element] = player
+
+        return list(player_dict.values())
+
+    def fill_queue(self, player: Penguin) -> None:
+        if player.battle_mode == 0 and not config.ALLOW_SINGLEPLAYER_SNOW:
+            # Singleplayer snow is disabled
+            return
+
+        if player.battle_mode == 1 and not config.ALLOW_SINGLEPLAYER_TUSK:
+            # Singleplayer tusk is disabled
+            return
+
+        if player.in_game:
+            # Player has found a match
+            return
+
+        # Fill up missing players with "None"
+        players = self.get_none_players([player])
+
+        self.logger.info(f'Found match: {players}')
+
+        match_types = {
+            0: self.create_normal_game,
+            1: self.create_tusk_game
+        }
+
+        match_types[player.battle_mode](*players)

--- a/app/engine/penguin.py
+++ b/app/engine/penguin.py
@@ -53,6 +53,9 @@ class Penguin(MetaplaceProtocol):
         self.power_card_stamina: int = 0
         self.played_cards: int = 0
 
+        self.login_time: int = 0
+        self.queue_time: int = 0
+
         self.mute_sounds: bool = False
         self.in_queue: bool = False
         self.is_ready: bool = False

--- a/app/engine/tusk.py
+++ b/app/engine/tusk.py
@@ -27,7 +27,6 @@ import time
 
 class TuskGame(Game):
     def __init__(self, fire: Penguin, snow: Penguin, water: Penguin) -> None:
-        self.server = fire.server
         self.water = water
         self.fire = fire
         self.snow = snow
@@ -48,6 +47,7 @@ class TuskGame(Game):
         self.grid = Grid(9, 5, self)
         self.timer = Timer(self)
 
+        self.server = self.clients[0].server
         self.logger = logging.getLogger('TuskGame')
         self.backgrounds = []
         self.rocks = []
@@ -166,17 +166,19 @@ class TuskGame(Game):
         # Randomize spawn positions
         random.shuffle(spawn_positions)
 
-        water = WaterNinja(self.water, **spawn_positions[0])
-        water.place_object()
-        self.water.ninja = water
+        ninja_classes = {
+            'snow': SnowNinja,
+            'fire': FireNinja,
+            'water': WaterNinja
+        }
 
-        fire = FireNinja(self.fire, **spawn_positions[1])
-        fire.place_object()
-        self.fire.ninja = fire
+        for index, client in enumerate(self.clients):
+            element = client.element
+            ninja_class = ninja_classes[element]
 
-        snow = SnowNinja(self.snow, **spawn_positions[2])
-        snow.place_object()
-        self.snow.ninja = snow
+            ninja = ninja_class(client, **spawn_positions[index])
+            ninja.place_object()
+            client.ninja = ninja
 
         sensei = Sensei(self, x=0, y=2)
         sensei.place_object()
@@ -198,21 +200,7 @@ class TuskGame(Game):
         self.tusk.hp = max_hp
 
     def spawn_ninjas(self) -> None:
-        water = self.objects.by_name('Water')
-        water.place_object()
-        water.idle_animation()
-        water.place_healthbar()
-
-        snow = self.objects.by_name('Snow')
-        snow.place_object()
-        snow.idle_animation()
-        snow.place_healthbar()
-
-        fire = self.objects.by_name('Fire')
-        fire.place_object()
-        fire.idle_animation()
-        fire.place_healthbar()
-
+        super().spawn_ninjas()
         self.sensei.place_object()
         self.sensei.idle_animation()
 

--- a/app/handlers/login.py
+++ b/app/handlers/login.py
@@ -7,6 +7,7 @@ from app import session
 import urllib.parse
 import logging
 import config
+import time
 
 @session.events.register('/version', login_required=False)
 def version_handler(client: Penguin):
@@ -99,6 +100,7 @@ def login_handler(client: Penguin, server_type: str, pid: int, token: str):
     client.logger = logging.getLogger(client.name)
 
     client.logged_in = True
+    client.login_time = time.time()
     client.send_login_message('Finalizing login, creating final user object')
     client.send_login_reply()
 

--- a/config.py
+++ b/config.py
@@ -24,12 +24,15 @@ try:
     MEDIA_LOCATION = os.environ.get('MEDIA_LOCATION')
     MEDIA_DOMAIN = urlparse(MEDIA_LOCATION).hostname
 
+    MATCHMAKING_TIMEOUT = int(os.environ.get('MATCHMAKING_TIMEOUT', '30'))
+    ALLOW_SINGLEPLAYER_SNOW = os.environ.get('ALLOW_SINGLEPLAYER_SNOW', 'False').lower() == 'true'
+    ALLOW_SINGLEPLAYER_TUSK = os.environ.get('ALLOW_SINGLEPLAYER_TUSK', 'True').lower() == 'true'
+
     POLICY_DOMAIN = os.environ.get('POLICY_DOMAIN', '*')
     POLICY_PORT = os.environ.get('POLICY_PORT', '*')
     ENABLE_POLICY_SERVER = os.environ.get('ENABLE_POLICY_SERVER', 'False').lower() == 'true'
 
     APPLY_WINDOWMANAGER_OFFSET = os.environ.get('APPLY_WINDOWMANAGER_OFFSET', 'False').lower() == 'true'
-    ENABLE_DEBUG_PLAYERS = os.environ.get('ENABLE_DEBUG_PLAYERS', 'False').lower() == 'true'
     ENABLE_DEBUG_LOGGING = os.environ.get('ENABLE_DEBUG_LOGGING', 'False').lower() == 'true'
     DISABLE_AUTHENTICATION = os.environ.get('DISABLE_AUTHENTICATION', 'False').lower() == 'true'
     DISABLE_ENEMY_AI = os.environ.get('DISABLE_ENEMY_AI', 'False').lower() == 'true'

--- a/config.py
+++ b/config.py
@@ -25,8 +25,8 @@ try:
     MEDIA_DOMAIN = urlparse(MEDIA_LOCATION).hostname
 
     MATCHMAKING_TIMEOUT = int(os.environ.get('MATCHMAKING_TIMEOUT', '30'))
-    ALLOW_SINGLEPLAYER_SNOW = os.environ.get('ALLOW_SINGLEPLAYER_SNOW', 'False').lower() == 'true'
-    ALLOW_SINGLEPLAYER_TUSK = os.environ.get('ALLOW_SINGLEPLAYER_TUSK', 'True').lower() == 'true'
+    ALLOW_FORCESTART_SNOW = os.environ.get('ALLOW_FORCESTART_SNOW', 'False').lower() == 'true'
+    ALLOW_FORCESTART_TUSK = os.environ.get('ALLOW_FORCESTART_TUSK', 'True').lower() == 'true'
 
     POLICY_DOMAIN = os.environ.get('POLICY_DOMAIN', '*')
     POLICY_PORT = os.environ.get('POLICY_PORT', '*')


### PR DESCRIPTION
I've implemented a matchmaking timeout that essentially just fills in the game with `NoneType` players, so that the match can start. You can configure this to be active in both game modes.

![image](https://github.com/Lekuruu/snowflake/assets/84310095/6d7e0136-4ea4-405a-a2e0-b2cde84ee039)

![image](https://github.com/Lekuruu/snowflake/assets/84310095/79640efc-2528-41a2-be18-b5a6c48b665e)
