### PR TITLE
Fix `tile_range` logic for tusk

### DIFF
--- a/app/objects/ninjas.py
+++ b/app/objects/ninjas.py
@@ -431,8 +431,28 @@ class Ninja(GameObject):
 
             distance = abs(tile.x - target_x) + abs(tile.y - target_y)
 
-            if distance <= self.range + target_object.tile_range:
+            if distance <= self.range:
                 yield tile
+
+            if target_object.tile_range <= 0:
+                continue
+
+            # Enemy has a bigger tile range to be attacked from
+            # Check if the ninja can attack in that range
+            surrounding_tiles = self.game.grid.surrounding_tiles(
+                center_x=tile.x,
+                center_y=tile.y,
+                distance=target_object.tile_range
+            )
+
+            for surrounding_tile in surrounding_tiles:
+                distance = (
+                    abs(surrounding_tile.x - target_x) +
+                    abs(surrounding_tile.y - target_y)
+                )
+
+                if distance <= self.range:
+                    yield tile
 
     def healable_tiles(self, target_x: int, target_y: int) -> Iterator["Ninja"]:
         if self.hp <= 0:
@@ -464,7 +484,7 @@ class Ninja(GameObject):
                 if ninja.hp > 0:
                     continue
 
-                # Ninja is dead, limit range to sorrounding tiles
+                # Ninja is dead, limit range to surrounding tiles
                 tiles = self.game.grid.surrounding_tiles(ninja.x, ninja.y)
                 current_tile = self.game.grid.get_tile(target_x, target_y)
 


### PR DESCRIPTION
A minor bug discovered by @JeffTheRock - In the original, tusk could be attacked from his surrounding tiles like this:

![image](https://github.com/user-attachments/assets/f1a2dc6b-a790-4ad7-90c7-32aad04f0f85)

However this was not the case with snowflake, until now.

I have tried to fix this previously with the `tile_range` attribute that every enemy has, but was only really used on tusk. However, the way that it worked was incorrect, because it was just extending the range of the attack, instead of actually checking the surrounding enemy tiles.

In a nutshell, this change actually makes water ninja fun, when you battle tusk.