### PR TITLE
Implement missing `SFX_MG_CJSnow_PowercardReviveEnd` sound effect

### DIFF
--- a/app/engine/cards.py
+++ b/app/engine/cards.py
@@ -404,5 +404,6 @@ class MemberCard(GameObject):
         self.client.ninja.revive_membercard_animation()
         self.client.member_card = None
 
-        time.sleep(1)
+        time.sleep(1.2)
+        self.client.ninja.play_sound('SFX_MG_CJSnow_PowercardReviveEnd')
         beam.remove_object()


### PR DESCRIPTION
I recently noticed a small oversight, which was a missing sound effect, when using the member card.
Here is how it sounded before:

https://github.com/user-attachments/assets/d6be62ee-ae4b-4561-b6db-068631712840

Here is how its supposed to sound:

https://github.com/user-attachments/assets/8c55a191-bf85-4198-acf4-939825fb34e4

