### PR TITLE
Fix Tusk icicle cleanup / tank splash / powercard selection state

### DIFF
--- a/app/handlers/game/cards.py
+++ b/app/handlers/game/cards.py
@@ -11,10 +11,6 @@ def on_card_clicked(client: Penguin, data: dict):
     if client.is_ready:
         return
 
-    if client.selected_member_card:
-        client.member_card.selected = False
-        client.member_card.remove()
-
     element = data['element']
     value = data['value']
     id = data['cardId']
@@ -27,6 +23,13 @@ def on_card_clicked(client: Penguin, data: dict):
 
     if card.element != element:
         return
+
+    if client.selected_member_card:
+        client.member_card.selected = False
+        client.member_card.remove()
+
+    if client.selected_card:
+        client.selected_card.remove()
 
     card.object.x = -1
     card.object.y = -1

--- a/app/objects/effects.py
+++ b/app/objects/effects.py
@@ -735,6 +735,7 @@ class TuskIcicle(Effect):
 
     def apply_damage(self) :
         target = self.game.grid[self.x, self.y]
+        self.remove_object()
 
         if not target:
             return
@@ -746,8 +747,7 @@ class TuskIcicle(Effect):
             return
 
         target.set_health(target.hp - self.game.tusk.attack)
-        self.remove_object()
-
+        
 class TuskIcicleRow:
     def __init__(self, game: "Game", row: int) -> None:
         self.first_row = row[0]

--- a/app/objects/enemies.py
+++ b/app/objects/enemies.py
@@ -691,10 +691,10 @@ class Tank(Enemy):
             left = self.game.grid[target.x-1, target.y]
             right = self.game.grid[target.x+1, target.y]
 
-            if left is not None and left.name in ('Water', 'Fire', 'Snow'):
+            if left is not None and left.name in ('Water', 'Fire', 'Snow') and left.hp > 0:
                 left.set_health(left.hp - self.attack / 2)
 
-            if right is not None and right.name in ('Water', 'Fire', 'Snow'):
+            if right is not None and right.name in ('Water', 'Fire', 'Snow') and right.hp > 0:
                 right.set_health(right.hp - self.attack / 2)
 
             effects = [
@@ -708,10 +708,10 @@ class Tank(Enemy):
             above = self.game.grid[target.x, target.y-1]
             below = self.game.grid[target.x, target.y+1]
 
-            if above is not None and above.name in ('Water', 'Fire', 'Snow'):
+            if above is not None and above.name in ('Water', 'Fire', 'Snow') and above.hp > 0:
                 above.set_health(above.hp - self.attack / 2)
 
-            if below is not None and below.name in ('Water', 'Fire', 'Snow'):
+            if below is not None and below.name in ('Water', 'Fire', 'Snow') and below.hp > 0:
                 below.set_health(below.hp - self.attack / 2)
 
             effects = [


### PR DESCRIPTION
1. When Tusk uses the icicle attack, the object should always be removed. It is currently only removing the object if the icicle hits a target.
2. Tank splash damage could damage dead ninjas, which would cause them to take damage and put them in a buggy state.
3. If you placed a powercard and then switch to a different powercard, it would keep the previous powercard selection on the board.