### PR TITLE
Multiple Bug fixes

### DIFF
--- a/app/engine/game.py
+++ b/app/engine/game.py
@@ -220,10 +220,6 @@ class Game:
                 # Hide disconnected ninjas
                 client.ninja.remove_object()
 
-            if all(client.disconnected or client.is_bot for client in self.clients):
-                # All players have disconnected
-                self.close()
-
             if all(ninja.hp <= 0 for ninja in self.ninjas):
                 # All ninjas have been defeated
                 break
@@ -272,6 +268,11 @@ class Game:
 
     def run_until_next_round(self) -> None:
         while True:
+            if all(client.disconnected or client.is_bot for client in self.clients):
+                # All players have disconnected
+                self.logger.debug("All ninjas have disconnected, ending session.")
+                self.close()
+
             for client in self.clients:
                 client.selected_card = None
                 client.is_ready = False

--- a/app/engine/game.py
+++ b/app/engine/game.py
@@ -272,6 +272,7 @@ class Game:
                 # All players have disconnected
                 self.logger.debug("All ninjas have disconnected, ending session.")
                 self.close()
+                return
 
             for client in self.clients:
                 client.selected_card = None

--- a/app/engine/game.py
+++ b/app/engine/game.py
@@ -893,7 +893,7 @@ class Game:
             snow_stamps = stamps.fetch_all_by_group(60, session=session)
 
             for client in self.clients:
-                if client.disconnected:
+                if client.disconnected or client.is_bot:
                     continue
 
                 if client.object.snow_ninja_rank < 24:

--- a/app/engine/penguin.py
+++ b/app/engine/penguin.py
@@ -256,7 +256,7 @@ class Penguin(MetaplaceProtocol):
         if config.DISABLE_STAMPS:
             return
 
-        if self.disconnected:
+        if self.disconnected or self.is_bot:
             return
 
         if not (stamp := stamps.fetch_one(id, session=session)):

--- a/app/engine/tusk.py
+++ b/app/engine/tusk.py
@@ -146,6 +146,13 @@ class TuskGame(Game):
         self.display_win_sequence()
 
         if not self.enemies:
+            for client in self.clients:
+                if not client.was_ko:
+                    continue
+
+                # Unlock "Up and at 'em" stamp
+                client.unlock_stamp(475)
+
             if all(client.was_ko for client in self.clients):
                 # Unlock "Team Revival" stamp
                 self.unlock_stamp(476)

--- a/app/engine/tusk.py
+++ b/app/engine/tusk.py
@@ -145,6 +145,11 @@ class TuskGame(Game):
         self.remove_targets()
         self.display_win_sequence()
 
+        if not self.enemies:
+            if all(client.was_ko for client in self.clients):
+                # Unlock "Team Revival" stamp
+                self.unlock_stamp(476)
+
         self.display_payout()
         self.remove_objects()
         self.close()
@@ -275,7 +280,7 @@ class TuskGame(Game):
             snow_stamps = stamps.fetch_all_by_group(60, session=session)
 
             for client in self.clients:
-                if client.disconnected:
+                if client.disconnected or client.is_bot:
                     continue
 
                 if client.object.snow_ninja_rank < 24:

--- a/app/objects/gameobject.py
+++ b/app/objects/gameobject.py
@@ -136,7 +136,7 @@ class GameObject:
             self.name,
             '0:1',  # TODO
             0,      # TODO
-            1,      # TODO
+            0 if self.on_click is None else 1,
             0       # TODO
         )
 

--- a/app/objects/ninjas.py
+++ b/app/objects/ninjas.py
@@ -272,14 +272,14 @@ class Ninja(GameObject):
             self.ghost.y = -1
 
     def on_ghost_click(self, client, object: GameObject, *args) -> None:
-        if client.ninja != self:
-            return
-
         if client.is_ready:
             return
 
         if client.selected_card:
             client.selected_card.place(object.x, object.y)
+            return
+
+        if client.ninja != self:
             return
 
         if self.client.selected_member_card:

--- a/app/protocols/metaplace/windows.py
+++ b/app/protocols/metaplace/windows.py
@@ -1,5 +1,6 @@
 
 from __future__ import annotations
+import logging
 from typing import Dict, Callable
 
 from app.data import WindowAction, MessageType, EventType
@@ -39,6 +40,8 @@ class SWFWindow:
         self.layer = layer # TODO: topLayer, bottomLayer, toolLayer
         self.asset_path = '' # TODO
         self.loaded = False
+
+        self.logger = logging.getLogger("WindowManager")
 
         self.on_load: Callable | None = None
         self.on_close: Callable | None = None


### PR DESCRIPTION
Hi, here's a collection of bug fixes me and Bale found while testing for NewCP :)

1. The Team Revival stamp is not checked for when the Tusk gamemode is being played as the start method of Game is completely overriden, which was an oversight.

2. Exclude AI bots from payout as that would often lead to crashes.

3. Fix WindowManager crashing for lacking a logger when attempting to make a log.

4. Don't award stamps to bots as that also leads to crashes.

5. Improve powercard placement as the ninja ghost object would often get prioritized and prevent the card from being placed.

6. End game early if all ninjas disconnect to save resources.

7. Grant the Up and at 'em stamp, which wasn't granted for the same reason Team Revival wasn't